### PR TITLE
Fix facebook login

### DIFF
--- a/packages/mobile/src/services/authFacebook.js
+++ b/packages/mobile/src/services/authFacebook.js
@@ -9,10 +9,11 @@ const getAccessData = async () => {
   let result;
 
   const offlineUser = await AsyncStorage.getItem('@facebook:accessData');
+
   if (offlineUser) {
     accessData = JSON.parse(offlineUser);
   } else {
-    result = await LoginManager.logInWithReadPermissions(['public_profile', 'email']);
+    result = await LoginManager.logInWithPermissions(['public_profile', 'email']);
 
     if (result.isCancelled) {
       return { error: 'Usuário cancelou o Login!' };
@@ -44,8 +45,8 @@ const getAccountInfo = accessData => new Promise((resolve, reject) => {
           }
 
           return resolve(result);
-        },
-      ),
+        }
+      )
     )
     .start();
 });


### PR DESCRIPTION
When I tried to login with facebook, I received the error message `logInWithReadPermissions is not a function`. I think the version 0.10.0 of `react-native-fbsdk` uses `logInWithPermissions` function.

Reference: https://github.com/facebook/react-native-fbsdk/issues/566